### PR TITLE
Changed from using Array.concat to [].concat

### DIFF
--- a/es5/lib/chainLink/connection.js
+++ b/es5/lib/chainLink/connection.js
@@ -60,7 +60,7 @@ var Connection = function () {
 				newArguments[_key] = arguments[_key];
 			}
 
-			_.useArguments = Array.concat(_.useArguments, newArguments);
+			_.useArguments = _.useArguments.concat(newArguments);
 			return this;
 		}
 	}, {
@@ -74,7 +74,7 @@ var Connection = function () {
 
 			var _ = (0, _incognito2.default)(this);
 
-			options = Array.concat(_.useArguments, options);
+			options = _.useArguments.concat(options);
 
 			var instance = new (Function.prototype.bind.apply(this.ChainLinkConstructor, [null].concat(_toConsumableArray(options))))();
 

--- a/es6/lib/chainLink/connection.js
+++ b/es6/lib/chainLink/connection.js
@@ -29,14 +29,14 @@ export default class Connection {
 
 	usingArguments(...newArguments) {
 		const _ = privateData(this);
-		_.useArguments = Array.concat(_.useArguments, newArguments);
+		_.useArguments = _.useArguments.concat(newArguments);
 		return this;
 	}
 
 	[addLink](...options) {
 		const _ = privateData(this);
 
-		options = Array.concat(_.useArguments, options);
+		options = _.useArguments.concat(options);
 
 		const instance = new this.ChainLinkConstructor(...options);
 


### PR DESCRIPTION
I was having an issue with mrt when I disabled babel-pollyfill which is a dependency of incognito. Since the only part of babel-pollyfill mrt uses is Array.concat I felt it was safe to convert these uses to the traditional way concatenating two array. I ran gulp test and got back all green, everything should be good to go.
